### PR TITLE
feat: add SAP Eventing element templates

### DIFF
--- a/eventing-connectors/element-templates/sap-eventing-intermediate-event-connector.json
+++ b/eventing-connectors/element-templates/sap-eventing-intermediate-event-connector.json
@@ -7,7 +7,7 @@
   "metadata": {
     "keywords": []
   },
-  "documentationRef": "https://docs.camunda.io/docs/next/components/camunda-integrations/overview/",
+  "documentationRef": "https://docs.camunda.io/docs/components/camunda-integrations/sap/eventing",
   "category": {
     "id": "connectors",
     "name": "Connectors"

--- a/eventing-connectors/element-templates/sap-eventing-message-start-event-connector.json
+++ b/eventing-connectors/element-templates/sap-eventing-message-start-event-connector.json
@@ -7,7 +7,7 @@
   "metadata": {
     "keywords": []
   },
-  "documentationRef": "https://docs.camunda.io/docs/next/components/camunda-integrations/overview/",
+  "documentationRef": "https://docs.camunda.io/docs/components/camunda-integrations/sap/eventing",
   "category": {
     "id": "connectors",
     "name": "Connectors"

--- a/eventing-connectors/element-templates/sap-eventing-outbound-connector.json
+++ b/eventing-connectors/element-templates/sap-eventing-outbound-connector.json
@@ -7,7 +7,7 @@
   "metadata": {
     "keywords": []
   },
-  "documentationRef": "https://docs.camunda.io/docs/next/components/camunda-integrations/overview/",
+  "documentationRef": "https://docs.camunda.io/docs/components/camunda-integrations/sap/eventing",
   "category": {
     "id": "connectors",
     "name": "Connectors"


### PR DESCRIPTION
- Introduced a new element template for the SAP Eventing Outbound Connector.
- The template allows sending cloud events to Advanced Event Mesh with various authentication methods including API key, Basic, Bearer token, and OAuth 2.0.
- Configurable properties include HTTP method, broker URL, topic or queue selection, connection timeouts, and payload structure.
- Supports error handling and response mapping with customizable retry logic.
- Comprehensive documentation reference for JSON/FEEL included for user guidance.