### PR TITLE
feat(odata): support v1 element template variable format

### DIFF
--- a/odata-connector/examples/s4-v1-get.bpmn
+++ b/odata-connector/examples/s4-v1-get.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="read_bps_from_s4_v1" name="Read BPs from S/4 (v1 fallback)" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Activity_v1_get" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="Activity_v1_get" name="query BPs from S/4 (v1 flat vars)">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:sap-odata:2" retries="0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="s4" target="destination" />
+          <zeebe:input source="/sap/opu/odata/sap/API_BUSINESS_PARTNER" target="oDataService" />
+          <zeebe:input source="A_BusinessPartner" target="entityOrEntitySet" />
+          <zeebe:input source="get" target="httpMethod.httpMethod" />
+          <zeebe:input source="V2" target="httpMethod.oDataVersionGet.oDataVersionGet" />
+          <zeebe:input source="CreatedByUser eq 'STUDENT037'" target="httpMethod.filter" />
+          <zeebe:input source="=false" target="httpMethod.oDataVersionGet.inlinecount" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="BusinessPartners" />
+          <zeebe:header key="errorExpression" value="=if error.code = &quot;400&quot; then&#10;  bpmnError(&quot;400&quot;, &quot;client request is bad&quot;, { errorMessage: error.message, errorCode: error.code })&#10;else if error.code = &quot;404&quot; then&#10;  bpmnError(&quot;404&quot;, &quot;queried resource not found&quot;, { errorMessage: error.message, errorCode: error.code })&#10;else if error.code = &quot;500&quot; then &#10;  bpmnError(&quot;500&quot;, &quot;server error&quot;, { errorMessage: error.message, errorCode: error.code })&#10;else if error.code = &quot;503&quot; then &#10;  bpmnError(&quot;503&quot;, &quot;I'm just an proxy teapot&quot;, { errorMessage: error.message, errorCode: error.code })&#10;else &#10;  null" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_v1_get" targetRef="EndEvent_1" />
+    <bpmn:boundaryEvent id="ErrorBoundary_1" attachedToRef="Activity_v1_get">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=errorMessage" target="ov_errorMessage" />
+          <zeebe:output source="=errorCode" target="ov_errorCode" />
+          <zeebe:output source="=error" target="ov_error" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDef_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ErrorBoundary_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="read_bps_from_s4_v1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="382" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_v1_get_di" bpmnElement="Activity_v1_get">
+        <dc:Bounds x="230" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ErrorBoundary_1_di" bpmnElement="ErrorBoundary_1">
+        <dc:Bounds x="282" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="230" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="330" y="118" />
+        <di:waypoint x="382" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="300" y="176" />
+        <di:waypoint x="300" y="196" />
+        <di:waypoint x="400" y="196" />
+        <di:waypoint x="400" y="136" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/LegacyODataConnector.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/LegacyODataConnector.java
@@ -1,0 +1,38 @@
+package io.camunda.connector.sap.odata;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.sap.odata.model.FallbackODataConnectorRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Connector worker for the legacy v1 task type {@code io.camunda:sap:odata:outbound:}.
+ *
+ * <p>Older element templates (pre-v2) used this task type with a flat variable structure — no
+ * {@code requestDetails} wrapper. This connector binds directly to {@link
+ * FallbackODataConnectorRequest}, converts to the canonical {@link
+ * io.camunda.connector.sap.odata.model.ODataConnectorRequest}, and delegates to the standard
+ * executor.
+ */
+@OutboundConnector(
+    name = LegacyODataConnector.NAME,
+    inputVariables = {},
+    type = LegacyODataConnector.TYPE)
+public class LegacyODataConnector implements OutboundConnectorFunction {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LegacyODataConnector.class);
+
+  public static final String NAME = "SAP_ODATA_CONNECTOR_LEGACY";
+  public static final String TYPE = "io.camunda:sap:odata:outbound:";
+
+  @Override
+  public Object execute(OutboundConnectorContext context) {
+    LOGGER.info("Legacy v1 task type '{}' — binding flat variables via fallback model", TYPE);
+    var fallback = context.bindVariables(FallbackODataConnectorRequest.class);
+    var request = fallback.toODataConnectorRequest();
+
+    ODataRequestExecutor requestExecutor = new ODataRequestExecutor();
+    return requestExecutor.executeRequest(request);
+  }
+}

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/ODataConnector.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/ODataConnector.java
@@ -7,7 +7,10 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.sap.odata.model.FallbackODataConnectorRequest;
 import io.camunda.connector.sap.odata.model.ODataConnectorRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @OutboundConnector(
     name = NAME,
@@ -27,6 +30,8 @@ import io.camunda.connector.sap.odata.model.ODataConnectorRequest;
       @ElementTemplate.PropertyGroup(id = "advanced", label = "Advanced")
     })
 public class ODataConnector implements OutboundConnectorFunction {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ODataConnector.class);
+
   public static final String NAME = "SAP_ODATA_CONNECTOR";
   public static final int VERSION = 2;
   // the format "io.camunda:<type>:<version>" is important as this
@@ -36,6 +41,16 @@ public class ODataConnector implements OutboundConnectorFunction {
   @Override
   public Object execute(OutboundConnectorContext context) {
     ODataConnectorRequest request = context.bindVariables(ODataConnectorRequest.class);
+
+    // Fallback for older element templates (pre-v2) that don't include the
+    // requestDetails.requestType discriminator — binding silently produces requestDetails = null.
+    if (request.requestDetails() == null) {
+      LOGGER.info(
+          "requestDetails is null — attempting fallback binding for older element template variables");
+      var fallback = context.bindVariables(FallbackODataConnectorRequest.class);
+      request = fallback.toODataConnectorRequest();
+    }
+
     // check that request.requestDetails() is of type BatchRequest
     if (request.requestDetails() instanceof BatchRequest) {
       ODataBatchRequestExecutor batchExecutor = new ODataBatchRequestExecutor();

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/ODataConnector.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/ODataConnector.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class ODataConnector implements OutboundConnectorFunction {
   private static final Logger LOGGER = LoggerFactory.getLogger(ODataConnector.class);
 
-  public static final String NAME = "SAP_ODATA_CONNECTOR";
+  public static final String NAME = "PATCHED_SAP_ODATA_CONNECTOR";
   public static final int VERSION = 2;
   // the format "io.camunda:<type>:<version>" is important as this
   // is in line w/ "zeebe-analytics", exporting usage of the connector task to mixpanel (for SaaS)

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/FallbackODataConnectorRequest.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/FallbackODataConnectorRequest.java
@@ -1,0 +1,45 @@
+package io.camunda.connector.sap.odata.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import java.util.Map;
+
+/**
+ * Fallback request model for parsing variables from older element templates (v1) that don't include
+ * the {@code requestDetails.requestType} discriminator property.
+ *
+ * <p>The v1 element template sent variables in a flat structure — {@code destination}, {@code
+ * oDataService}, {@code entityOrEntitySet}, {@code httpMethod.*}, {@code payload} — identical to
+ * the pre-batch {@code ODataConnectorRequest} shape. The {@link HttpMethod} sealed interface and
+ * its Jackson {@code @JsonSubTypes} are structurally unchanged, so this record reuses them directly
+ * without any manual conversion.
+ *
+ * @see ODataConnectorRequest
+ * @see ODataRequestDetails.SimpleRequest
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FallbackODataConnectorRequest(
+    @NotEmpty String destination,
+    @Pattern(regexp = "^([/=]).*", message = "oDataService must start with a '/'") @NotEmpty
+        String oDataService,
+    @Pattern(regexp = "^[^/].*$", message = "entityOrEntitySet must not start with a '/'") @NotEmpty
+        String entityOrEntitySet,
+    @Valid HttpMethod httpMethod,
+    Map<String, Object> payload) {
+
+  /**
+   * Converts this v1 flat representation into a proper {@link ODataConnectorRequest} with a {@link
+   * ODataRequestDetails.SimpleRequest}. The v1 element template only supported simple requests (no
+   * batch), so the conversion always produces a {@code SimpleRequest}.
+   *
+   * @return fully typed {@link ODataConnectorRequest}
+   */
+  public ODataConnectorRequest toODataConnectorRequest() {
+    return new ODataConnectorRequest(
+        destination,
+        oDataService,
+        new ODataRequestDetails.SimpleRequest(entityOrEntitySet, httpMethod, payload));
+  }
+}

--- a/odata-connector/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
+++ b/odata-connector/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
@@ -1,1 +1,2 @@
 io.camunda.connector.sap.odata.ODataConnector
+io.camunda.connector.sap.odata.LegacyODataConnector

--- a/odata-connector/src/test/java/io/camunda/connector/sap/odata/BaseTest.java
+++ b/odata-connector/src/test/java/io/camunda/connector/sap/odata/BaseTest.java
@@ -1,0 +1,60 @@
+package io.camunda.connector.sap.odata;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.readString;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public abstract class BaseTest {
+
+  protected static final String HOTFIX_CASES_PATH = "src/test/resources/hotfix.json";
+
+  // Actual values that secrets resolve to
+  public interface ActualValue {
+    String DESTINATION = "s4-test";
+  }
+
+  // Secret placeholder keys — must match {{secrets.XXX}} references in hotfix.json
+  protected interface SecretsConstant {
+    String DESTINATION = "my_destination";
+  }
+
+  protected static Stream<String> hotfixTestCases() throws IOException {
+    return loadTestCasesFromResourceFile(HOTFIX_CASES_PATH);
+  }
+
+  /**
+   * Loads test cases from a JSON file. Supports both a single JSON object and an array of objects.
+   */
+  @SuppressWarnings("unchecked")
+  protected static Stream<String> loadTestCasesFromResourceFile(final String fileWithTestCasesUri)
+      throws IOException {
+    final String cases = readString(new File(fileWithTestCasesUri).toPath(), UTF_8);
+    final ObjectMapper mapper = new ObjectMapper();
+    JsonNode root = mapper.readTree(cases);
+
+    List<Object> items;
+    if (root.isArray()) {
+      items = mapper.readValue(cases, ArrayList.class);
+    } else {
+      items = List.of(mapper.readValue(cases, Object.class));
+    }
+
+    return items.stream()
+        .map(
+            value -> {
+              try {
+                return mapper.writeValueAsString(value);
+              } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+}

--- a/odata-connector/src/test/java/io/camunda/connector/sap/odata/HotfixBindingTest.java
+++ b/odata-connector/src/test/java/io/camunda/connector/sap/odata/HotfixBindingTest.java
@@ -1,0 +1,87 @@
+package io.camunda.connector.sap.odata;
+
+import static io.camunda.connector.sap.odata.OutboundBaseTest.getContextBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.sap.odata.model.FallbackODataConnectorRequest;
+import io.camunda.connector.sap.odata.model.HttpMethod;
+import io.camunda.connector.sap.odata.model.ODataConnectorRequest;
+import io.camunda.connector.sap.odata.model.ODataRequestDetails;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Validates that variables from an older element template (v1) — which lack the {@code
+ * requestDetails.requestType} discriminator — can be gracefully parsed via {@link
+ * FallbackODataConnectorRequest} and converted to a proper {@link ODataConnectorRequest}.
+ */
+public class HotfixBindingTest extends BaseTest {
+
+  @ParameterizedTest
+  @MethodSource("hotfixTestCases")
+  void bindingToODataConnectorRequest_losesRequestDetails_forOldETVariables(String input) {
+    // Given: JSON input shaped like v1 element template (no requestType discriminator)
+    OutboundConnectorContext context = getContextBuilder().variables(input).build();
+
+    // When: binding to ODataConnectorRequest — it doesn't throw, but requestDetails is lost
+    var request = context.bindVariables(ODataConnectorRequest.class);
+
+    // Then: top-level fields that don't require a discriminator are still populated
+    assertThat(request.destination()).isEqualTo(ActualValue.DESTINATION);
+    assertThat(request.oDataService()).isNotBlank();
+
+    // Then: requestDetails is null because the v1 ET doesn't provide requestType discriminator
+    // — this is the root cause of the customer's runtime failure
+    assertThat(request.requestDetails())
+        .as(
+            "v1 ET variables lack 'requestDetails.requestType', so requestDetails cannot be deserialized")
+        .isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("hotfixTestCases")
+  void bindingToFallbackRequest_shouldSucceed_forOldETVariables(String input) {
+    // Given: JSON input shaped like v1 element template (flat, no requestDetails wrapper)
+    OutboundConnectorContext context = getContextBuilder().variables(input).build();
+
+    // When: binding to FallbackODataConnectorRequest — reuses HttpMethod sealed interface directly
+    var request = context.bindVariables(FallbackODataConnectorRequest.class);
+
+    // Then: core fields are present
+    assertThat(request.destination()).isEqualTo(ActualValue.DESTINATION);
+    assertThat(request.oDataService()).isNotBlank();
+    assertThat(request.entityOrEntitySet()).isNotBlank();
+
+    // Then: httpMethod was deserialized as the correct typed instance via Jackson polymorphism
+    assertThat(request.httpMethod()).isNotNull();
+    assertThat(request.httpMethod()).isInstanceOf(HttpMethod.Get.class);
+
+    HttpMethod.Get getMethod = (HttpMethod.Get) request.httpMethod();
+    assertThat(getMethod.oDataVersionGet()).isNotNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("hotfixTestCases")
+  void fallbackRequest_convertsToODataConnectorRequest(String input) {
+    // Given: fallback-parsed request from v1 ET variables
+    OutboundConnectorContext context = getContextBuilder().variables(input).build();
+    var fallback = context.bindVariables(FallbackODataConnectorRequest.class);
+
+    // When: converting to a proper ODataConnectorRequest
+    ODataConnectorRequest converted = fallback.toODataConnectorRequest();
+
+    // Then: top-level fields are preserved
+    assertThat(converted.destination()).isEqualTo(fallback.destination());
+    assertThat(converted.oDataService()).isEqualTo(fallback.oDataService());
+
+    // Then: requestDetails is a SimpleRequest (v1 ET only supported simple requests)
+    assertThat(converted.requestDetails()).isInstanceOf(ODataRequestDetails.SimpleRequest.class);
+    var simple = (ODataRequestDetails.SimpleRequest) converted.requestDetails();
+    assertThat(simple.entityOrEntitySet()).isEqualTo(fallback.entityOrEntitySet());
+    assertThat(simple.payload()).isEqualTo(fallback.payload());
+
+    // Then: httpMethod is the same typed instance — no conversion needed
+    assertThat(simple.httpMethod()).isSameAs(fallback.httpMethod());
+  }
+}

--- a/odata-connector/src/test/java/io/camunda/connector/sap/odata/OutboundBaseTest.java
+++ b/odata-connector/src/test/java/io/camunda/connector/sap/odata/OutboundBaseTest.java
@@ -1,0 +1,11 @@
+package io.camunda.connector.sap.odata;
+
+import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
+
+public class OutboundBaseTest extends BaseTest {
+
+  public static OutboundConnectorContextBuilder getContextBuilder() {
+    return OutboundConnectorContextBuilder.create()
+        .secret(SecretsConstant.DESTINATION, ActualValue.DESTINATION);
+  }
+}

--- a/odata-connector/src/test/resources/hotfix.json
+++ b/odata-connector/src/test/resources/hotfix.json
@@ -1,0 +1,14 @@
+{
+  "destination": "{{secrets.my_destination}}",
+  "oDataService": "/sap/api_my_obj/sap/my_obj",
+  "entityOrEntitySet": "MyEntity",
+  "httpMethod" : {
+    "httpMethod": "get",
+    "oDataVersionGet": {
+      "oDataVersionGet": "V4",
+      "count": false
+    },
+    "filter": "MyProperty eq '12345'",
+    "expand": "_MyNavProperty"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,25 @@
     <version.junit-jupiter>5.14.1</version.junit-jupiter>
     <version.mockito>5.21.0</version.mockito>
     <version.testcontainers>1.21.4</version.testcontainers>
+    <version.lombok>1.18.42</version.lombok>
     <plugin.version.spotless-maven-plugin>3.1.0</plugin.version.spotless-maven-plugin>
   </properties>
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${version.lombok}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary

Adds backward compatibility so the OData connector can process variables sent by **v1 (pre-batch) element templates** in addition to the current v2 format. Both the v2 task type (with fallback detection) and the legacy v1 task type are supported.

## Problem

The v1 element template sends variables in a **flat structure** (`destination`, `oDataService`, `entityOrEntitySet`, `httpMethod.*`, `payload`) without the `requestDetails.requestType` discriminator that the v2 connector expects. When `context.bindVariables(ODataConnectorRequest.class)` receives v1 input, it silently sets `requestDetails = null`, causing runtime failures downstream.

Additionally, some customer deployments use the legacy task type `io.camunda:sap:odata:outbound:` (with trailing colon) which no v2 worker listens for.

## Approach

Two complementary mechanisms ensure v1 templates work regardless of which task type they use:

1. **Fallback in `ODataConnector` (type `io.camunda:sap-odata:2`)**: After binding, if `requestDetails` is `null`, the connector re-binds using `FallbackODataConnectorRequest` and converts to a standard request. This catches v1 templates that happen to target the v2 task type.

2. **`LegacyODataConnector` (type `io.camunda:sap:odata:outbound:`)**: A separate connector class registered via SPI that directly binds flat v1 variables through `FallbackODataConnectorRequest` and delegates to `ODataRequestExecutor`.

## Changes

| File | Change |
|---|---|
| `FallbackODataConnectorRequest.java` | New — fallback model with validation (`@NotEmpty`, `@Pattern`, `@Valid`) and conversion to `ODataConnectorRequest` |
| `LegacyODataConnector.java` | New — connector worker for legacy task type `io.camunda:sap:odata:outbound:` |
| `ODataConnector.java` | Modified — fallback detection when `requestDetails` is null after binding |
| `OutboundConnectorFunction` (SPI) | Modified — added `LegacyODataConnector` to service loader |
| `pom.xml` | Modified — added Lombok annotation processor path (required for Java 22+ on release/8.7) |
| `s4-v1-get.bpmn` | New — example BPMN with v1 flat variable structure for testing |
| `BaseTest.java` | New — JSON test case loader |
| `OutboundBaseTest.java` | New — connector context builder helper |
| `HotfixBindingTest.java` | New — 3 parameterized tests for binding and conversion |
| `hotfix.json` | New — test fixture with v1 variable structure |

## Testing

### Unit tests
3 parameterized tests in `HotfixBindingTest`:
1. Proves `ODataConnectorRequest` binding produces `requestDetails = null` for v1 input (documents the problem)
2. Proves `FallbackODataConnectorRequest` binding succeeds with typed `HttpMethod` instances
3. Proves `toODataConnectorRequest()` correctly converts fallback → canonical request

### E2E validation on BTP (SaaS 8.7 cluster)
- **v2 task type with v1 variables**: Deployed `s4-v1-get.bpmn` (task type `io.camunda:sap-odata:2`, flat variables). Logs confirmed fallback triggered and OData request constructed correctly.
- **Legacy task type**: Deployed BPMN with task type `io.camunda:sap:odata:outbound:`. `LegacyODataConnector` picked up the job, bound flat variables, and executed the OData request successfully.