### PR TITLE
fix(version): make it work with connectors 8.9

### DIFF
--- a/.github/workflows/rfc-reusable-deploy.yml
+++ b/.github/workflows/rfc-reusable-deploy.yml
@@ -157,3 +157,27 @@ jobs:
           cf login -a ${{ inputs.cf_api_endpoint }} -u ${{ steps.vault-secrets.outputs.SAP_CLOUDFOUNDRY_EMAIL }} \
           -p ${{ steps.vault-secrets.outputs.SAP_CLOUDFOUNDRY_PASSWORD }} -o ${{ inputs.cf_org }} -s ${{ inputs.cf_space }}
           cf deploy ./ -f
+
+      - name: dump app + MTA logs on failure
+        if: failure()
+        env:
+          APP: ${{ needs.create-cluster.outputs.deployment-name }}
+        run: |
+          set +e
+          echo "=== cf target ==="
+          cf target
+          echo "=== cf apps ==="
+          cf apps
+          echo "=== cf app $APP ==="
+          cf app "$APP"
+          echo "=== cf events $APP ==="
+          cf events "$APP"
+          echo "=== cf logs $APP --recent ==="
+          cf logs "$APP" --recent
+          echo "=== cf mta-ops ==="
+          cf mta-ops
+          OP_ID=$(cf mta-ops | awk 'NR>1 && $2=="deploy" {print $1}' | tail -1)
+          if [ -n "$OP_ID" ]; then
+            echo "=== cf dmol -i $OP_ID ==="
+            cf dmol -i "$OP_ID"
+          fi

--- a/odata-connector/pom.xml
+++ b/odata-connector/pom.xml
@@ -5,12 +5,11 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.8.0-SNAPSHOT</version>
+    <version>8.9.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.odata</groupId>
   <artifactId>odata</artifactId>
-  <version>8.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>sap-odata-connector</name>
@@ -27,8 +26,8 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-core</artifactId>
       <version>${version.camunda}</version>
-      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-validation</artifactId>
@@ -41,6 +40,12 @@
       <groupId>com.sap.cloud.sdk</groupId>
       <artifactId>sdk-core</artifactId>
       <version>${version.cloud-sdk}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -52,6 +57,14 @@
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -65,9 +78,16 @@
     <!-- Element template generator annotations (compile-time only) -->
     <dependency>
       <groupId>io.camunda.connector</groupId>
-      <artifactId>element-template-generator-core</artifactId>
+      <artifactId>element-template-generator-annotations</artifactId>
       <version>${version.camunda}</version>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-object-mapper</artifactId>
+      <version>${version.camunda}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- test dependencies -->
@@ -107,13 +127,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${version.slf4j}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
       <version>${version.testcontainers}</version>
@@ -126,12 +139,6 @@
       <artifactId>spring-boot-starter-camunda-connectors</artifactId>
       <version>${version.camunda}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>
@@ -224,60 +231,7 @@
           </connectors>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <!-- profile to auto format -->
-    <profile>
-      <id>autoFormat</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>spotless-format</id>
-                <goals>
-                  <goal>apply</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- profile to perform strict validation checks -->
-    <profile>
-      <id>checkFormat</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>spotless-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <phase>validate</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/odata-connector/pom.xml
+++ b/odata-connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.9.0-SNAPSHOT</version>
+    <version>8.9.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.odata</groupId>

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/ODataConnectorRequest.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/ODataConnectorRequest.java
@@ -1,6 +1,6 @@
 package io.camunda.connector.sap.odata.model;
 
-import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -11,14 +11,14 @@ public record ODataConnectorRequest(
             group = "sap",
             label = "BTP destination name",
             description = "BTP destination pointing to the SAP System to connect to (e.g. a4h)",
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
         @NotEmpty
         String destination,
     @TemplateProperty(
             group = "sap",
             label = "OData base service path",
             description = "absolute base path, e.g. /sap/opu/odata/dmo/case",
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
         @Pattern(regexp = "^([/=]).*", message = "oDataService must start with a '/'")
         @NotEmpty
         String oDataService,

--- a/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/ODataRequestDetails.java
+++ b/odata-connector/src/main/java/io/camunda/connector/sap/odata/model/ODataRequestDetails.java
@@ -2,7 +2,7 @@ package io.camunda.connector.sap.odata.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.camunda.connector.generator.dsl.Property.FeelMode;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector.sap</groupId>
   <artifactId>connectors-sap-parent</artifactId>
-  <version>8.8.0-SNAPSHOT</version>
+  <version>8.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>rfc-connector</module>
@@ -25,7 +25,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <version.slf4j>2.0.17</version.slf4j>
-    <version.camunda>8.8.8</version.camunda>
+    <version.camunda>8.9.1</version.camunda>
     <version.cloud-sdk>5.27.0</version.cloud-sdk>
     <version.assertj>3.27.7</version.assertj>
     <version.junit-jupiter>6.0.3</version.junit-jupiter>
@@ -100,11 +100,54 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
+
+  <profiles>
+    <!-- auto-format sources during build (inherited by all modules) -->
+    <profile>
+      <id>autoFormat</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-format</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- strict format validation (inherited by all modules) -->
+    <profile>
+      <id>checkFormat</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>validate</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector.sap</groupId>
   <artifactId>connectors-sap-parent</artifactId>
-  <version>8.9.0-SNAPSHOT</version>
+  <version>8.9.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>rfc-connector</module>
@@ -25,7 +25,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <version.slf4j>2.0.17</version.slf4j>
-    <version.camunda>8.9.1</version.camunda>
+    <version.camunda>8.9.4</version.camunda>
     <version.cloud-sdk>5.27.0</version.cloud-sdk>
     <version.assertj>3.27.7</version.assertj>
     <version.junit-jupiter>6.0.3</version.junit-jupiter>

--- a/rfc-connector/pom.xml
+++ b/rfc-connector/pom.xml
@@ -5,12 +5,11 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.8.0-SNAPSHOT</version>
+    <version>8.9.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.rfc</groupId>
   <artifactId>rfc</artifactId>
-  <version>8.8.0-SNAPSHOT</version>
   <!--  necessary for SAP BTP cf to pick up SAP's JCo lib -->
   <packaging>war</packaging>
 
@@ -18,12 +17,9 @@
   <description>Camunda RFC protocol outbound Connector</description>
 
   <properties>
-    <version.spring-boot>3.5.13</version.spring-boot>
-    <version.spring-boot-starter-camunda-connectors>${version.camunda}</version.spring-boot-starter-camunda-connectors>
+    <version.spring-boot>4.0.5</version.spring-boot>
     <version.logback>1.5.32</version.logback>
-    <plugin.version.maven-war-plugin>3.4.0</plugin.version.maven-war-plugin>
     <plugin.version.maven-exec-plugin>3.6.3</plugin.version.maven-exec-plugin>
-    <plugin.version.maven-spring-boot>${version.spring-boot}</plugin.version.maven-spring-boot>
   </properties>
 
   <dependencyManagement>
@@ -75,12 +71,6 @@
         <version>${version.spring-boot}</version>
         <type>pom</type>
         <scope>import</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
     </dependencies>
 
@@ -118,7 +108,7 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>spring-boot-starter-camunda-connectors</artifactId>
-      <version>${version.spring-boot-starter-camunda-connectors}</version>
+      <version>${version.camunda}</version>
     </dependency>
 
     <!-- connector-specific -->
@@ -201,9 +191,16 @@
     <!-- Element template generator annotations (compile-time only) -->
     <dependency>
       <groupId>io.camunda.connector</groupId>
-      <artifactId>element-template-generator-core</artifactId>
+      <artifactId>element-template-generator-annotations</artifactId>
       <version>${version.camunda}</version>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-object-mapper</artifactId>
+      <version>${version.camunda}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- test dependencies -->
@@ -234,13 +231,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${version.slf4j}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>
@@ -251,13 +241,6 @@
         <version>${plugin.version.maven-exec-plugin}</version>
         <configuration>
           <mainClass>io.camunda.connector.sap.rfc.ApplicationRuntime</mainClass>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <useDefaultManifestFile>false</useDefaultManifestFile>
         </configuration>
       </plugin>
       <plugin>
@@ -287,16 +270,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${plugin.version.maven-spring-boot}</version>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
+        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <id>repackage</id>
@@ -308,54 +284,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <!-- profile to auto format -->
-    <profile>
-      <id>autoFormat</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>spotless-format</id>
-                <goals>
-                  <goal>apply</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- profile to perform strict validation checks -->
-    <profile>
-      <id>checkFormat</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>spotless-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <phase>validate</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/rfc-connector/pom.xml
+++ b/rfc-connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.9.0-SNAPSHOT</version>
+    <version>8.9.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.rfc</groupId>

--- a/rfc-connector/pom.xml
+++ b/rfc-connector/pom.xml
@@ -200,7 +200,6 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-object-mapper</artifactId>
       <version>${version.camunda}</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- test dependencies -->

--- a/rfc-connector/src/main/java/io/camunda/connector/sap/rfc/model/RFCConnectorRequest.java
+++ b/rfc-connector/src/main/java/io/camunda/connector/sap/rfc/model/RFCConnectorRequest.java
@@ -1,6 +1,6 @@
 package io.camunda.connector.sap.rfc.model;
 
-import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
@@ -9,7 +9,7 @@ public record RFCConnectorRequest(
     @TemplateProperty(
             label = "BTP destination name",
             description = "BTP destination pointing to the SAP System to connect to (e.g. a4h)",
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
         @NotEmpty
         String destination,
     @TemplateProperty(
@@ -22,12 +22,12 @@ public record RFCConnectorRequest(
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String moduleType,
-    @TemplateProperty(label = "BAPI/module name", feel = Property.FeelMode.optional) @NotEmpty
+    @TemplateProperty(label = "BAPI/module name", feel = FeelMode.optional) @NotEmpty
         String moduleName,
     @TemplateProperty(
             label = "exporting parameter",
             description = "variables to send to the the module/BAPI",
-            feel = Property.FeelMode.optional,
+            feel = FeelMode.optional,
             optional = true,
             defaultValue = "=[{name:\"param\", type:\"type\", value:\"value\"}]")
         @Pattern(
@@ -39,7 +39,7 @@ public record RFCConnectorRequest(
     @TemplateProperty(
             label = "importing parameter",
             description = "which variables the module/BAPI returns should be picked up",
-            feel = Property.FeelMode.optional,
+            feel = FeelMode.optional,
             optional = true,
             defaultValue = "=[{name:\"param\", type:\"type\"}]")
         @Pattern(
@@ -51,7 +51,7 @@ public record RFCConnectorRequest(
             label = "changing parameter",
             description =
                 "which variables the module/BAPI receives and returns should be processed",
-            feel = Property.FeelMode.optional,
+            feel = FeelMode.optional,
             optional = true,
             defaultValue = "=[{name:\"param\", type:\"type\", value:\"value\"}]",
             condition =
@@ -67,7 +67,7 @@ public record RFCConnectorRequest(
             label = "tables parameter",
             description =
                 "which tables the module/BAPI receives and returns should be managed,\n for RETURN table BAPIRET2, set 'isReturn' to true",
-            feel = Property.FeelMode.optional,
+            feel = FeelMode.optional,
             optional = true,
             type = TemplateProperty.PropertyType.String,
             defaultValue =


### PR DESCRIPTION
This pull request updates both the OData and RFC SAP Connector modules to use the latest dependencies, improves annotation usage, and streamlines the Maven build configuration. The changes focus on updating parent and dependency versions, switching to improved annotation packages, cleaning up unnecessary dependencies, and centralizing formatting plugins in the parent POM for consistency across modules.

**Dependency and Version Updates:**

- Updated the parent POM and all module POMs (`pom.xml`, `odata-connector/pom.xml`, `rfc-connector/pom.xml`) to use newer versions of Camunda, SAP Cloud SDK, and Spring Boot dependencies. This ensures compatibility and access to recent features and fixes. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R15) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L28-R28) [[3]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL8-L13) [[4]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL8-L26)

- Updated the annotation imports in `ODataConnectorRequest.java`, `ODataRequestDetails.java`, and `RFCConnectorRequest.java` to use `FeelMode` from `generator.java.annotation` instead of the deprecated DSL location. This modernizes the code and aligns with current best practices. [[1]](diffhunk://#diff-355d09a5ef6eaf1b78f1b5cdd5aaeb7221518d85197ff253dde20105927dd8aeL3-R3) [[2]](diffhunk://#diff-355d09a5ef6eaf1b78f1b5cdd5aaeb7221518d85197ff253dde20105927dd8aeL14-R21) [[3]](diffhunk://#diff-a5ce3f854ad593fec87085411b143737555974550f12bf8d3b7609b58c15b438L5-R5) [[4]](diffhunk://#diff-00d139020d3d9c70c5e0ca437ee0da09716001edd2988419d1790b908f603718L3-R3) [[5]](diffhunk://#diff-00d139020d3d9c70c5e0ca437ee0da09716001edd2988419d1790b908f603718L12-R12) [[6]](diffhunk://#diff-00d139020d3d9c70c5e0ca437ee0da09716001edd2988419d1790b908f603718L25-R30) [[7]](diffhunk://#diff-00d139020d3d9c70c5e0ca437ee0da09716001edd2988419d1790b908f603718L42-R42) [[8]](diffhunk://#diff-00d139020d3d9c70c5e0ca437ee0da09716001edd2988419d1790b908f603718L54-R54)

**Build and Dependency Management Improvements:**

- Replaced `element-template-generator-core` with `element-template-generator-annotations` and added `connector-object-mapper` as a provided dependency in both connector modules, supporting improved code generation and object mapping. [[1]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL68-R92) [[2]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL204-R205)

- Removed unnecessary dependencies and exclusions, such as `slf4j-jdk14`, `logback-classic`, and redundant exclusions for logging libraries, to simplify the dependency tree and avoid conflicts. [[1]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aR43-R48) [[2]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aR61-R68) [[3]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL109-L115) [[4]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL129-L134) [[5]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL78-L83) [[6]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL237-L243)

**Maven Build and Formatting Plugin Centralization:**

- Centralized the Spotless formatting and validation plugin configuration in the parent `pom.xml` and removed redundant plugin and profile definitions from the module POMs. This ensures consistent code formatting and validation across all modules and reduces duplication. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R103-R152) [[2]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL227-L281) [[3]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL289-R275) [[4]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL312-L360)

- Updated plugin versions and configurations for `spring-boot-maven-plugin` and removed unnecessary `maven-jar-plugin` configuration in the RFC connector. [[1]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL256-L262) [[2]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL289-R275)

These changes collectively modernize the project, reduce maintenance overhead, and improve build reliability.