### PR TITLE
chore: Update version to 8.10

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,7 @@ Open a PR against `release/X.Y` with the new version in `pom.xml`:
 <!-- change this -->
 <version>8.9.3-SNAPSHOT</version>
 <!-- to this -->
-<version>8.9.4-SNAPSHOT</version>
+<version>8.10.0-SNAPSHOT</version>
 ```
 
 Merge the PR and wait for CI to go green.

--- a/odata-connector/element-templates/sap-odata-connector.json
+++ b/odata-connector/element-templates/sap-odata-connector.json
@@ -3,9 +3,6 @@
   "name" : "SAP OData Connector",
   "id" : "SAP_ODATA_CONNECTOR",
   "description" : "This connector allows you to interact with an SAP System via OData v2 + v4",
-  "metadata" : {
-    "keywords" : [ ]
-  },
   "documentationRef" : "https://docs.camunda.io/docs/components/camunda-integrations/sap",
   "version" : 2,
   "category" : {
@@ -620,7 +617,7 @@
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",
-    "description" : "Name of variable to store the response in",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
     "group" : "output",
     "binding" : {
       "key" : "resultVariable",
@@ -630,7 +627,7 @@
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",
-    "description" : "Expression to map the response into process variables",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
     "feel" : "required",
     "group" : "output",
     "binding" : {
@@ -665,10 +662,21 @@
     "id" : "retryBackoff",
     "label" : "Retry backoff",
     "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT0S",
+    "value" : "PT30S",
     "group" : "retries",
     "binding" : {
       "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "optional" : true,
+    "group" : "retries",
+    "binding" : {
+      "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"

--- a/odata-connector/pom.xml
+++ b/odata-connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.9.4-SNAPSHOT</version>
+    <version>8.10.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.odata</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <version.testcontainers>2.0.4</version.testcontainers>
     <version.lombok>1.18.44</version.lombok>
     <plugin.version.spotless-maven-plugin>3.4.0</plugin.version.spotless-maven-plugin>
-    <version.jackson>2.21.2</version.jackson>
+    <version.jackson>2.22.0</version.jackson>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector.sap</groupId>
   <artifactId>connectors-sap-parent</artifactId>
-  <version>8.9.4-SNAPSHOT</version>
+  <version>8.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>rfc-connector</module>
@@ -25,7 +25,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <version.slf4j>2.0.17</version.slf4j>
-    <version.camunda>8.9.4</version.camunda>
+    <version.camunda>8.10.0-SNAPSHOT</version.camunda>
     <version.cloud-sdk>5.27.0</version.cloud-sdk>
     <version.assertj>3.27.7</version.assertj>
     <version.junit-jupiter>6.0.3</version.junit-jupiter>

--- a/rfc-connector/element-templates/sap-rfc-connector.json
+++ b/rfc-connector/element-templates/sap-rfc-connector.json
@@ -2,9 +2,6 @@
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name" : "SAP RFC connector",
   "id" : "io.camunda.connector.sap.rfc.outbound.v1",
-  "metadata" : {
-    "keywords" : [ ]
-  },
   "documentationRef" : "https://docs.camunda.io/xxx",
   "version" : 1,
   "category" : {
@@ -198,7 +195,7 @@
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",
-    "description" : "Name of variable to store the response in",
+    "description" : "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
     "group" : "output",
     "binding" : {
       "key" : "resultVariable",
@@ -208,7 +205,7 @@
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",
-    "description" : "Expression to map the response into process variables",
+    "description" : "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
     "feel" : "required",
     "group" : "output",
     "binding" : {
@@ -243,10 +240,21 @@
     "id" : "retryBackoff",
     "label" : "Retry backoff",
     "description" : "ISO-8601 duration to wait between retries",
-    "value" : "PT0S",
+    "value" : "PT30S",
     "group" : "retries",
     "binding" : {
       "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "jobTimeout",
+    "label" : "Job timeout",
+    "description" : "ISO-8601 duration after which Zeebe considers this job timed out if not yet completed. Leave empty to use the default timeout",
+    "optional" : true,
+    "group" : "retries",
+    "binding" : {
+      "key" : "jobTimeout",
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"

--- a/rfc-connector/pom.xml
+++ b/rfc-connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector.sap</groupId>
     <artifactId>connectors-sap-parent</artifactId>
-    <version>8.9.4-SNAPSHOT</version>
+    <version>8.10.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.camunda.connector.sap.rfc</groupId>


### PR DESCRIPTION
This pull request introduces version upgrades and enhancements to both the OData and RFC SAP connectors, focusing on improving documentation, configuration defaults, and adding new retry/job timeout options.

**Version Upgrades:**

* Bumped the project and module versions from `8.9.4-SNAPSHOT` to `8.10.0-SNAPSHOT` in `pom.xml`, `rfc-connector/pom.xml`, and `odata-connector/pom.xml`, and updated the Camunda dependency version accordingly. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R15) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L28-R28) [[3]](diffhunk://#diff-cae8cdd21298a5934435c13aba8d099a743312987296ecc785cf08a2af2833fbL8-R8) [[4]](diffhunk://#diff-4a2511e73c713a2135e13999423ed97e3f2f9a2f2e1fa63a3e1e34713bcf413aL8-R8) [[5]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL42-R42)

**Element Template Improvements:**

* Enhanced the descriptions for `resultVariable` and `resultExpression` fields in both `sap-odata-connector.json` and `sap-rfc-connector.json` to include direct links to the relevant documentation for better usability. [[1]](diffhunk://#diff-13f8087baeb859508c8151acafcac9f56a32750d8867ca14f9bc5fe439c9782bL623-R620) [[2]](diffhunk://#diff-13f8087baeb859508c8151acafcac9f56a32750d8867ca14f9bc5fe439c9782bL633-R630) [[3]](diffhunk://#diff-cb2ca03b20525b4e4cd7ff86f16164ce2e394fb7bd4fb12959dd42b7f06622beL201-R198) [[4]](diffhunk://#diff-cb2ca03b20525b4e4cd7ff86f16164ce2e394fb7bd4fb12959dd42b7f06622beL211-R208)
* Updated the default value for the `retryBackoff` property from `"PT0S"` to `"PT30S"` in both connector templates, providing a more reasonable default retry interval. [[1]](diffhunk://#diff-13f8087baeb859508c8151acafcac9f56a32750d8867ca14f9bc5fe439c9782bL668-R682) [[2]](diffhunk://#diff-cb2ca03b20525b4e4cd7ff86f16164ce2e394fb7bd4fb12959dd42b7f06622beL246-R260)
* Added a new optional `jobTimeout` property to both connector templates, allowing users to specify a custom job timeout duration. [[1]](diffhunk://#diff-13f8087baeb859508c8151acafcac9f56a32750d8867ca14f9bc5fe439c9782bL668-R682) [[2]](diffhunk://#diff-cb2ca03b20525b4e4cd7ff86f16164ce2e394fb7bd4fb12959dd42b7f06622beL246-R260)

**Template Metadata Cleanup:**

* Removed the empty `"metadata"` section from both connector element template JSON files for clarity and to reduce unnecessary clutter. [[1]](diffhunk://#diff-13f8087baeb859508c8151acafcac9f56a32750d8867ca14f9bc5fe439c9782bL6-L8) [[2]](diffhunk://#diff-cb2ca03b20525b4e4cd7ff86f16164ce2e394fb7bd4fb12959dd42b7f06622beL5-L7)